### PR TITLE
feat(ova): add non-interactive mode for automated OVA builds

### DIFF
--- a/.github/workflows/notify-ova-build.yml
+++ b/.github/workflows/notify-ova-build.yml
@@ -1,0 +1,17 @@
+name: Notify OVA Build
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger-ova-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger OVA build in ai-workspace
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CT_WORKSPACE_DISPATCH_TOKEN }}
+          repository: calltelemetry/ai-workspace
+          event-type: build-ova
+          client-payload: '{"version": "${{ github.event.release.tag_name }}"}'

--- a/ova/prep.sh
+++ b/ova/prep.sh
@@ -191,9 +191,15 @@ EOF
 echo "Appliance prep complete."
 echo "IMPORTANT - After this next step you must access the appliance on port 2222 - NOT PORT 22."
 
-# Prompt the user for confirmation to apply the SSH port change
-read -p "The SSH management port must changed to 2222. Applying this change will disconnect your SSH session. Do you want to apply this change and restart the SSH service? (yes/no): " response < /dev/tty
-
+# Support non-interactive mode for automated builds (Packer, CI, etc.)
+# Set CT_NONINTERACTIVE=1 to skip the interactive prompt and apply SSH port change automatically
+if [ "${CT_NONINTERACTIVE:-0}" = "1" ]; then
+  echo "Non-interactive mode detected. Applying SSH port change automatically..."
+  response="yes"
+else
+  # Prompt the user for confirmation to apply the SSH port change
+  read -p "The SSH management port must changed to 2222. Applying this change will disconnect your SSH session. Do you want to apply this change and restart the SSH service? (yes/no): " response < /dev/tty
+fi
 
 if [ "$response" = "yes" ]; then
   # Change SSH port to 2222


### PR DESCRIPTION
## Summary
- Add `CT_NONINTERACTIVE=1` support to prep.sh to skip interactive SSH port change prompt
- Add `CT_PREP_SCRIPT_PATH` support to cli.sh to use local prep script instead of downloading

## Problem
Packer automated OVA builds were failing because `prep.sh` requires interactive confirmation for SSH port changes. The `read -p` with `/dev/tty` doesn't work in non-interactive environments, causing the SSH port to remain at 22 and conflict with docker-compose port bindings.

## Solution
- Check for `CT_NONINTERACTIVE=1` environment variable in prep.sh
- If set, automatically apply SSH port change without prompting
- Support `CT_PREP_SCRIPT_PATH` in cli.sh to use a bundled script instead of downloading

## Test plan
- [ ] Manual test: run prep.sh interactively (should still prompt)
- [ ] Automated test: run with `CT_NONINTERACTIVE=1` (should skip prompt)
- [ ] Packer build test: verify OVA builds successfully with non-interactive mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)