### PR TITLE
fix: resolve alertmanager and jtapi-sidecar container crashes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,7 +210,8 @@ services:
     command:
       - --config.file=/etc/alertmanager/alertmanager.yml
       - --storage.path=/alertmanager
-      - --web.external-url=/alertmanager
+      - --web.route-prefix=/alertmanager
+      - --web.external-url=${ALERTMANAGER_EXTERNAL_URL:-http://localhost/alertmanager}
     volumes:
       - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - alertmanager-data:/alertmanager
@@ -363,6 +364,8 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317}
       # Disable Spring Boot tracing autoconfiguration when OTel is off
       - MANAGEMENT_TRACING_ENABLED=${OTEL_ENABLED:-false}
+      # Spring Boot 3.5+ bean override (prevents conventionErrorViewResolver conflict)
+      - SPRING_MAIN_ALLOW_BEAN_DEFINITION_OVERRIDING=true
     volumes:
       - jtapi-jars:/app/jars
     depends_on:


### PR DESCRIPTION
## Summary

- **alertmanager**: `--web.external-url=/alertmanager` was a relative path with no scheme. Alertmanager v0.28.1 requires a full URL. Split into `--web.route-prefix=/alertmanager` + `--web.external-url` with a configurable env var defaulting to `http://localhost/alertmanager`.
- **jtapi-sidecar**: Spring Boot 3.5+ moved `webmvc.autoconfigure` classes, causing a `BeanDefinitionOverrideException` for `conventionErrorViewResolver` on startup. Added `SPRING_MAIN_ALLOW_BEAN_DEFINITION_OVERRIDING=true` to suppress the conflict.

## Test plan

- [ ] `docker compose up -d alertmanager` — container should reach `healthy` (was crash-looping with "invalid scheme" error)
- [ ] `docker compose up -d --profile jtapi jtapi-sidecar` — container should start without `BeanDefinitionOverrideException`
- [ ] Alertmanager UI accessible at `/alertmanager` via Caddy reverse proxy
- [ ] Override `ALERTMANAGER_EXTERNAL_URL` in `.env` for non-localhost deployments