### PR TITLE
fix(ova): soft-fail postgres repair, align with ct-release

### DIFF
--- a/ova/cli.sh
+++ b/ova/cli.sh
@@ -311,14 +311,39 @@ repair_postgres_compat() {
     return 0
   fi
 
+  # Search INSTALL_DIR, then next to cli.sh. We deliberately do NOT search
+  # PWD: this function may run under sudo/root and executing an arbitrary
+  # helper from a user-controlled CWD is a local-privilege-escalation risk.
+  # download_bundle places the helper in INSTALL_DIR, so the trusted paths
+  # are sufficient under normal operation.
+  #
+  # Resolve CURRENT_SCRIPT_PATH to an absolute path before taking dirname, so
+  # the script_dir fallback works even when cli.sh was invoked via a relative
+  # path or bare name on $PATH.
   local helper=""
-  local script_dir
-  script_dir="$(cd "$(dirname "$CURRENT_SCRIPT_PATH")" 2>/dev/null && pwd)" || script_dir=""
+  local script_dir=""
+  local resolved_script_path=""
+  if [ -n "${CURRENT_SCRIPT_PATH:-}" ]; then
+    if command -v realpath >/dev/null 2>&1; then
+      resolved_script_path="$(realpath "$CURRENT_SCRIPT_PATH" 2>/dev/null)" || resolved_script_path=""
+    elif command -v readlink >/dev/null 2>&1; then
+      resolved_script_path="$(readlink -f "$CURRENT_SCRIPT_PATH" 2>/dev/null)" || resolved_script_path=""
+    fi
+    if [ -z "$resolved_script_path" ]; then
+      case "$CURRENT_SCRIPT_PATH" in
+        /*) resolved_script_path="$CURRENT_SCRIPT_PATH" ;;
+        */*) resolved_script_path="$(cd "$(dirname "$CURRENT_SCRIPT_PATH")" 2>/dev/null && pwd)/$(basename "$CURRENT_SCRIPT_PATH")" || resolved_script_path="" ;;
+        *) resolved_script_path="$(command -v -- "$CURRENT_SCRIPT_PATH" 2>/dev/null)" || resolved_script_path="" ;;
+      esac
+    fi
+    if [ -n "$resolved_script_path" ]; then
+      script_dir="$(cd "$(dirname "$resolved_script_path")" 2>/dev/null && pwd)" || script_dir=""
+    fi
+  fi
 
   for candidate in \
     "${INSTALL_DIR}/postgres-bitnami-convert.sh" \
-    "${script_dir:+${script_dir}/postgres-bitnami-convert.sh}" \
-    "${PWD}/postgres-bitnami-convert.sh"; do
+    "${script_dir:+${script_dir}/postgres-bitnami-convert.sh}"; do
     [ -z "$candidate" ] && continue
     if [ -f "$candidate" ]; then
       helper="$candidate"
@@ -327,8 +352,10 @@ repair_postgres_compat() {
   done
 
   if [ -z "$helper" ]; then
-    echo "[WARN] PostgreSQL compatibility repair helper not found in ${INSTALL_DIR}, ${script_dir:-(script dir unknown)}, or ${PWD}." >&2
-    echo "       Skipping repair; data directory already healthy or helper missing from bundle." >&2
+    echo "[WARN] PostgreSQL compatibility repair helper needed but not found in ${INSTALL_DIR}${script_dir:+ or ${script_dir}}." >&2
+    echo "       Data directory is missing canonical config files (postgresql.conf / pg_hba.conf / pg_ident.conf);" >&2
+    echo "       startup or migrations may fail. Re-run the upgrade with a bundle that includes" >&2
+    echo "       postgres-bitnami-convert.sh, or install it manually into ${INSTALL_DIR} and re-run." >&2
     return 0
   fi
 
@@ -2417,11 +2444,15 @@ download_bundle() {
   fi
 
   # postgres compatibility repair helper — write to INSTALL_DIR explicitly so
-  # repair_postgres_compat can find it regardless of the caller's CWD.
+  # repair_postgres_compat can find it regardless of the caller's CWD. Surface
+  # cp/chmod failures so we don't claim success on a permissions/disk error.
   if [ -f "$extract_dir/postgres-bitnami-convert.sh" ]; then
-    cp "$extract_dir/postgres-bitnami-convert.sh" "${INSTALL_DIR}/postgres-bitnami-convert.sh"
-    chmod +x "${INSTALL_DIR}/postgres-bitnami-convert.sh"
-    echo "  [OK] postgres-bitnami-convert.sh"
+    local dst="${INSTALL_DIR}/postgres-bitnami-convert.sh"
+    if cp "$extract_dir/postgres-bitnami-convert.sh" "$dst" && chmod +x "$dst"; then
+      echo "  [OK] postgres-bitnami-convert.sh"
+    else
+      echo "  [WARN] postgres-bitnami-convert.sh (failed to install to ${dst} — check permissions and disk space)"
+    fi
   fi
 
   # prometheus/prometheus.yml

--- a/ova/cli.sh
+++ b/ova/cli.sh
@@ -299,14 +299,27 @@ get_current_postgres_image() {
 # canonical config files were missing from the bind-mounted data directory.
 repair_postgres_compat() {
   local image="$1"
+  local pg_data="${INSTALL_DIR}/postgres-data/data"
+
+  # Skip if no cluster exists yet.
+  if [ ! -f "${pg_data}/PG_VERSION" ]; then
+    return 0
+  fi
+
+  # Skip if all canonical config files are already present — nothing to repair.
+  if [ -f "${pg_data}/postgresql.conf" ] && [ -f "${pg_data}/pg_hba.conf" ] && [ -f "${pg_data}/pg_ident.conf" ]; then
+    return 0
+  fi
+
   local helper=""
   local script_dir
-  script_dir="$(cd "$(dirname "$CURRENT_SCRIPT_PATH")" && pwd)"
+  script_dir="$(cd "$(dirname "$CURRENT_SCRIPT_PATH")" 2>/dev/null && pwd)" || script_dir=""
 
   for candidate in \
     "${INSTALL_DIR}/postgres-bitnami-convert.sh" \
-    "${script_dir}/postgres-bitnami-convert.sh" \
+    "${script_dir:+${script_dir}/postgres-bitnami-convert.sh}" \
     "${PWD}/postgres-bitnami-convert.sh"; do
+    [ -z "$candidate" ] && continue
     if [ -f "$candidate" ]; then
       helper="$candidate"
       break
@@ -314,17 +327,17 @@ repair_postgres_compat() {
   done
 
   if [ -z "$helper" ]; then
-    echo "[FAIL] PostgreSQL compatibility repair helper not found." >&2
-    echo "       Expected postgres-bitnami-convert.sh in ${INSTALL_DIR} or next to cli.sh." >&2
-    return 1
+    echo "[WARN] PostgreSQL compatibility repair helper not found in ${INSTALL_DIR}, ${script_dir:-(script dir unknown)}, or ${PWD}." >&2
+    echo "       Skipping repair; data directory already healthy or helper missing from bundle." >&2
+    return 0
   fi
 
   chmod +x "$helper" 2>/dev/null || true
 
   if [ -n "$image" ] && [ "$image" != "unknown" ]; then
-    bash "$helper" --image "$image" --data-dir "${INSTALL_DIR}/postgres-data/data"
+    bash "$helper" --image "$image" --data-dir "$pg_data"
   else
-    bash "$helper" --data-dir "${INSTALL_DIR}/postgres-data/data"
+    bash "$helper" --data-dir "$pg_data"
   fi
 }
 
@@ -2403,10 +2416,11 @@ download_bundle() {
     fi
   fi
 
-  # postgres compatibility repair helper
+  # postgres compatibility repair helper — write to INSTALL_DIR explicitly so
+  # repair_postgres_compat can find it regardless of the caller's CWD.
   if [ -f "$extract_dir/postgres-bitnami-convert.sh" ]; then
-    cp "$extract_dir/postgres-bitnami-convert.sh" ./postgres-bitnami-convert.sh
-    chmod +x ./postgres-bitnami-convert.sh
+    cp "$extract_dir/postgres-bitnami-convert.sh" "${INSTALL_DIR}/postgres-bitnami-convert.sh"
+    chmod +x "${INSTALL_DIR}/postgres-bitnami-convert.sh"
     echo "  [OK] postgres-bitnami-convert.sh"
   fi
 


### PR DESCRIPTION
## Summary
- `repair_postgres_compat` now early-returns when data dir is already healthy (all three canonical config files present) or when no cluster exists. Eliminates a spurious upgrade abort for appliances that don't need repair.
- Missing helper is now `[WARN]` + soft-continue, not `[FAIL]` + hard abort. Matches the source-of-truth cli.sh in `calltelemetry/ct-release` and every shipped GCS bundle.
- `download_bundle` writes the helper to `${INSTALL_DIR}/postgres-bitnami-convert.sh` explicitly instead of `./`, removing the CWD-dependent placement.

## Background
A customer upgrading to 0.8.6.2 hit:
```
[FAIL] PostgreSQL compatibility repair helper not found.
       Expected postgres-bitnami-convert.sh in /home/calltelemetry or next to cli.sh.
```

Forensics across GCS (`gs://ct_releases/releases/0.8.6{,.1,.2,.3}/`), the top-level `gs://ct_releases/cli.sh`, and `calltelemetry/ct-release:main/ova/cli.sh` all use the soft-fail variant and ship the helper via `bundle-manifest.yml`. The hard-fail error text exists **only** in this repo's `master/ova/cli.sh` (from commits `62463d9`, `a89d076`, `0165853`).

That means the customer pulled cli.sh from this repo's raw URL (or via a script that did), which drifted from the release pipeline's authoritative source. This PR reconciles.

Companion PR: [calltelemetry/ct-release#24](https://github.com/calltelemetry/ct-release/pull/24) applies the same guard-hardening upstream in the source of truth.

## Why this PR matters even though ct-release is authoritative
Anyone pulling `https://raw.githubusercontent.com/calltelemetry/calltelemetry/master/ova/cli.sh` — there are customers and install docs that do — currently gets a stricter script than any published bundle can satisfy. Reconciling makes the public repo safe to mirror from, even if it's not the canonical build input anymore.

Longer-term: either retire `ova/` from this repo entirely (and redirect install docs to `gs://ct_releases/cli.sh`), or wire a sync job from `ct-release`. This PR is the immediate-safety fix; structural reconciliation is a separate conversation.

## Test plan
- [ ] `bash -n ova/cli.sh` (syntax — already verified locally)
- [ ] Simulate upgrade on appliance with healthy data dir → no warning, no repair invoked
- [ ] Simulate upgrade on appliance missing `postgresql.conf` → helper runs if present, `[WARN]` + skip if not
- [ ] Confirm `download_bundle` writes helper to `$INSTALL_DIR` after bundle extraction