### PR TITLE
feat(cli): add --rc channel for staging appliance RC opt-in

### DIFF
--- a/ova/cli.sh
+++ b/ova/cli.sh
@@ -2092,6 +2092,7 @@ show_help() {
   echo "  status              Show application status and diagnostics"
   echo "  update              Update to latest stable release (default)"
   echo "  update --latest     Update to latest build (including pre-releases)"
+  echo "  update --rc         Update to latest release candidate (rc channel)"
   echo "  update <version>    Update to specific version (e.g., 0.8.4-rc191)"
   echo "                      Options: --force-upgrade, --no-cleanup, --ipv6"
   echo "  rollback            Roll back to previous docker-compose configuration"
@@ -2926,6 +2927,10 @@ update() {
         version="latest"
         shift
         ;;
+      --rc)
+        version="rc"
+        shift
+        ;;
       *)
         if [ -z "$version" ]; then
           version="$1"
@@ -2958,6 +2963,17 @@ update() {
       return 1
     fi
     echo "Latest version: $version"
+  elif [ "$version" = "rc" ]; then
+    echo "Fetching latest release candidate..."
+    version=$(curl -sfL "${GCS_BASE_URL}/latest-rc.txt" 2>/dev/null)
+    if [ -z "$version" ]; then
+      echo "[FAIL] Failed to fetch latest RC version"
+      echo ""
+      echo "No RC promoted to the rc channel yet."
+      echo "Specify a version manually: cli.sh update <version>"
+      return 1
+    fi
+    echo "Latest RC version: $version"
   fi
 
   # Get current version

--- a/ova/cli.sh
+++ b/ova/cli.sh
@@ -2944,7 +2944,7 @@ update() {
   # Default (no version) = stable, use --latest for bleeding edge
   if [ -z "$version" ] || [ "$version" = "stable" ]; then
     echo "Fetching latest stable version..."
-    version=$(curl -sfL "${GCS_BASE_URL}/latest-stable.txt" 2>/dev/null)
+    version=$(curl -sfL "${GCS_BASE_URL}/latest-stable.txt" 2>/dev/null | tr -d '[:space:]')
     if [ -z "$version" ]; then
       echo "[FAIL] Failed to fetch latest stable version"
       echo ""
@@ -2955,7 +2955,7 @@ update() {
     echo "Latest stable version: $version"
   elif [ "$version" = "latest" ]; then
     echo "Fetching latest version (including pre-releases)..."
-    version=$(curl -sfL "${GCS_BASE_URL}/latest.txt" 2>/dev/null)
+    version=$(curl -sfL "${GCS_BASE_URL}/latest.txt" 2>/dev/null | tr -d '[:space:]')
     if [ -z "$version" ]; then
       echo "[FAIL] Failed to fetch latest version"
       echo ""
@@ -2965,12 +2965,19 @@ update() {
     echo "Latest version: $version"
   elif [ "$version" = "rc" ]; then
     echo "Fetching latest release candidate..."
-    version=$(curl -sfL "${GCS_BASE_URL}/latest-rc.txt" 2>/dev/null)
+    version=$(curl -sfL "${GCS_BASE_URL}/latest-rc.txt" 2>/dev/null | tr -d '[:space:]')
     if [ -z "$version" ]; then
       echo "[FAIL] Failed to fetch latest RC version"
       echo ""
       echo "No RC promoted to the rc channel yet."
       echo "Specify a version manually: cli.sh update <version>"
+      return 1
+    fi
+    if [[ "$version" != *-rc* ]]; then
+      echo "[FAIL] RC channel contains a non-RC version: $version"
+      echo ""
+      echo "The rc channel marker does not point to a release candidate."
+      echo "Contact the release team or specify a version manually: cli.sh update <version>"
       return 1
     fi
     echo "Latest RC version: $version"

--- a/ova/cli.sh
+++ b/ova/cli.sh
@@ -2973,10 +2973,14 @@ update() {
       echo "Specify a version manually: cli.sh update <version>"
       return 1
     fi
-    if [[ "$version" != *-rc* ]]; then
-      echo "[FAIL] RC channel contains a non-RC version: $version"
+    # Strict format check — latest-rc.txt is a public GCS marker. Reject anything
+    # that isn't a recognized release-candidate tag before using it to build a
+    # download URL. Supports both 3-segment (0.8.6-rc271) and 4-segment
+    # (0.8.6.5-rc1) version schemes.
+    if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?-rc[0-9]+$ ]]; then
+      echo "[FAIL] RC channel contains an invalid version: $version"
       echo ""
-      echo "The rc channel marker does not point to a release candidate."
+      echo "Expected format: X.Y.Z-rcN or X.Y.Z.W-rcN (e.g. 0.8.6-rc271 or 0.8.6.5-rc1)."
       echo "Contact the release team or specify a version manually: cli.sh update <version>"
       return 1
     fi


### PR DESCRIPTION
## Summary

Adds `cli.sh update --rc` which fetches `latest-rc.txt` from GCS. Mirrors the existing `--latest` flag pattern but reads a separate channel marker so staging appliances can opt in to the latest validated release candidate without typing the exact version string.

Companion change to [calltelemetry/ct-release#64](https://github.com/calltelemetry/ct-release/pull/64) (merged), which added the `rc` channel to `promote-release.yml` (writes `latest-rc.txt` on GCS).

## Channel matrix

| Flag | GCS marker | Who uses it |
|---|---|---|
| (no flag, default) | `latest-stable.txt` | production appliances |
| `--latest` | `latest.txt` | bleeding-edge opt-in |
| **`--rc`** *(new)* | **`latest-rc.txt`** | staging appliances validating RCs |
| `<version>` | direct — no marker | explicit, one-shot install |

RC promotion is **independent** of stable promotion — `promote-release.yml -f channel=rc` does NOT touch `latest-stable.txt` or `latest.txt`, so production appliances are unaffected by RC channel activity.

## Why

Today, validating an RC on staging requires typing the exact version:

```bash
sudo cli.sh update 0.8.6.5-rc1
```

With this change, staging appliances just run:

```bash
sudo cli.sh update --rc
```

One fewer thing to remember, one fewer source of typo-induced failed updates.

## Usage flow

```bash
# 1. Cut RC (already works today)
gh workflow run unified-release.yml --repo calltelemetry/ct-release \
  -f version=0.8.6.5-rc1 -f target_branch=0.8.6-stable

# 2. After internal validation, promote to rc channel
gh workflow run promote-release.yml --repo calltelemetry/ct-release \
  -f version=0.8.6.5-rc1 -f channel=rc

# 3. Staging appliances pull it
sudo cli.sh update --rc
```

## Test plan

- [x] Bash syntax check: `bash -n ova/cli.sh` passes
- [ ] Manual test after merge: cut a fresh RC, promote to rc channel, run `cli.sh update --rc` on a staging appliance, verify it installs the promoted version
- [ ] Verify fallback: run `cli.sh update --rc` before any RC is promoted — should fail gracefully with the `No RC promoted to the rc channel yet` message

## Risk

**Low.** Purely additive — new flag, new elif branch. Does not change behavior of existing flags (`--latest`, `--stable`, `<version>`, or default).