### PR TITLE
ova(0.8.5.3): add release manifest for the 0.8.5 stable hotfix line

### DIFF
--- a/ova/versions/0.8.5.3.yaml
+++ b/ova/versions/0.8.5.3.yaml
@@ -1,0 +1,106 @@
+version: "3.8"
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - ./certs:/certs:ro
+    networks:
+      - ct
+
+  vue-web:
+    image: "calltelemetry/vue:0.8.5.3"
+    restart: "always"
+    expose:
+      - "80"
+    networks:
+      - ct
+
+  traceroute:
+    image: "calltelemetry/traceroute:0.7.3"
+    user: root
+    expose:
+      - "4100"
+    networks:
+      - ct
+
+  db:
+    image: "bitnamilegacy/postgresql:14"
+    user: root
+    restart: "always"
+    environment:
+      - POSTGRES_USER=calltelemetry
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=calltelemetry_prod
+    expose:
+      - "5432"
+    volumes:
+      - ./postgres-data:/bitnami/postgresql
+    networks:
+      - ct
+
+  web:
+    image: "calltelemetry/web:0.8.5.3"
+    restart: "always"
+    user: root
+    expose:
+      - 4000
+      - 4080
+    ports:
+      - "80:4080"
+      - "22:3022"
+    environment:
+      - DB_USER=calltelemetry
+      - DB_PASSWORD=postgres
+      - DB_HOSTNAME=db
+      - DB_NAME=calltelemetry_prod
+      - DB_PORT=5432
+      - EXTERNAL_IP=$DEFAULT_IPV4
+      - LOGGING_LEVEL=warning
+      - ADMIN_NODE=TRUE
+      - WORKER_NODE=TRUE
+      - CERT_KEY=/home/app/cert/appliance_key.pem
+      - CERT_PUBLIC=/home/app/cert/appliance.crt
+      # can be HACKNEY, IBROWSE, MINT, GUN or HTTPC.
+      - HTTP_ADAPTER=HACKNEY
+      - LOG_PATH=/var/log
+      - ERL_CRASH_DUMP=/tmp/crash-dumps/erl_crash.dump
+      - ERL_CRASH_DUMP_NICE=1
+    tmpfs:
+      - /var/log:rw,mode=0555,size=5000m
+    networks:
+      - ct
+    volumes:
+      - ./certs:/home/app/cert:rw
+      - ./crash-dumps:/tmp/crash-dumps:rw
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "7" # Keeps 7 days of logs
+        compress: "true" # Compresses rotated files
+
+  nats:
+    image: "nats:2.11"
+    command: "-c /etc/nats/nats.conf"
+    volumes:
+      - ./nats.conf:/etc/nats/nats.conf
+    expose:
+      - "4222"
+    networks:
+      - ct
+
+networks:
+  ct:
+    # enable_ipv6: true
+
+volumes:
+  certs:
+    driver: local
+  crash-dumps:
+    driver: local
+  traefik-logs:
+    driver: local


### PR DESCRIPTION
## Summary

Adds \`ova/versions/0.8.5.3.yaml\` — the compose manifest for the 0.8.5 stable line's third hotfix. Mirrors \`0.8.5-rc18.yaml\` (the last rc on the line) with only two image refs bumped:

  - \`calltelemetry/vue:0.8.5.3\`
  - \`calltelemetry/web:0.8.5.3\`

\`traceroute\` stays at \`0.7.3\` — deliberate isolation from the 0.8.6 line (which uses \`traceroute:0.8.4-rc147\`).

## Why

The 0.8.5.1 and 0.8.5.2 hotfixes we shipped earlier on the 0.8.5-stable line did NOT have manifest YAMLs added to this repo (verified — \`ls ova/versions/0.8.5.*\` shows only the rc files). This PR closes that gap with 0.8.5.3 and establishes the pattern for any future 0.8.5.N hotfix that follows.

## What ships in 0.8.5.3 (customer-facing)

Three rounds of customer hotfixes on top of 0.8.5-rc44:

| Version | What |
|---|---|
| 0.8.5.1 | Alerts tab Save flow fix; pipeline-results stats SQL aggregation + purge gaps |
| 0.8.5.2 | ServiceNow token cache clears on pre-update credentials |
| **0.8.5.3** | **Rule serializer round-trip: 12 previously-dropped editable fields now emit; Jason.Encoder emits announcement_greetings; toggle never indeterminate; TanStack cache hydration on save; Rule TS interface aligned with backend** |

## \`cli.sh update 0.8.5.3\`

Already works without script changes:

  - \`is_version_084_or_higher\` regex \`^([0-9]+)\\\.([0-9]+)\\\.([0-9]+)\` correctly classifies \`0.8.5.3\` as ≥ 0.8.4 (RAM/disk checks apply)
  - GCS bundle URL pattern \`\${GCS_BUNDLE_BASE_URL}/\${version}/calltelemetry-bundle-\${version}.tar.gz\` handles arbitrary version strings
  - Customer can run: \`./cli.sh update 0.8.5.3\` once the bundle is built and uploaded

## NOT modified

- \`latest-stable.txt\` — **global stable channel preserved** (this is an explicit-version-only release on the 0.8.5 backport line)
- \`0.8.6-release\` branch — never touched in this session
- GitHub release Latest tag — \`0.8.6.6-rc17\` remains Latest on both cisco-cdr and ct-quasar (the 0.8.5.3 GitHub releases were created without \`--latest\`)

## Docker images already published

  - https://hub.docker.com/r/calltelemetry/web/tags (\`0.8.5.3\` multi-arch)
  - https://hub.docker.com/r/calltelemetry/vue/tags (\`0.8.5.3\` multi-arch)

## Next step (maintainer action)

Trigger the existing release workflow (\`create-ova-release.yml\` workflow_dispatch) with \`version=0.8.5.3\` to build and upload the GCS bundle. Once uploaded, customers on the 0.8.5 line can pull via \`cli.sh update 0.8.5.3\`.

## Test plan

- [x] \`diff ova/versions/0.8.5-rc18.yaml ova/versions/0.8.5.3.yaml\` shows only the two image-ref lines changed
- [x] Verified \`is_version_084_or_higher 0.8.5.3\` matches the existing regex
- [x] Verified the rc-channel regex at line 2980 does NOT gate explicit-version updates (only \`cli.sh update rc\`)
- [ ] Maintainer: trigger bundle build workflow + verify \`cli.sh update 0.8.5.3\` against a test appliance